### PR TITLE
change file extension check to only ensure the path ends with a valid extension

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,2 @@
+# Default ignored files
+/workspace.xml

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="JavaScriptSettings">
+    <option name="languageLevel" value="ES6" />
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/tfproviderdocs.iml" filepath="$PROJECT_DIR$/.idea/tfproviderdocs.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/tfproviderdocs.iml
+++ b/.idea/tfproviderdocs.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/check/file_extension.go
+++ b/check/file_extension.go
@@ -26,7 +26,7 @@ var ValidRegistryFileExtensions = []string{
 
 func LegacyFileExtensionCheck(path string) error {
 	if !FilePathEndsWithExtensionFrom(path, ValidLegacyFileExtensions) {
-		return fmt.Errorf("file does not end with a valid extension (%s), valid values: %v", GetFileExtension(path), ValidLegacyFileExtensions)
+		return fmt.Errorf("file does not end with a valid extension, valid extensions: %v", ValidLegacyFileExtensions)
 	}
 
 	return nil
@@ -34,28 +34,10 @@ func LegacyFileExtensionCheck(path string) error {
 
 func RegistryFileExtensionCheck(path string) error {
 	if !FilePathEndsWithExtensionFrom(path, ValidRegistryFileExtensions) {
-		return fmt.Errorf("file does not end with a valid extension (%s), valid values: %v", GetFileExtension(path), ValidLegacyFileExtensions)
+		return fmt.Errorf("file does not end with a valid extension, valid extensions: %v", ValidLegacyFileExtensions)
 	}
 
 	return nil
-}
-
-// GetFileExtension fetches file extensions including those with multiple periods.
-// This is a replacement for filepath.Ext(), which only returns the final period and extension.
-func GetFileExtension(path string) string {
-	filename := filepath.Base(path)
-
-	if filename == "." {
-		return ""
-	}
-
-	dotIndex := strings.IndexByte(filename, '.')
-
-	if dotIndex > 0 {
-		return filename[dotIndex:]
-	}
-
-	return filename
 }
 
 func FilePathEndsWithExtensionFrom(path string, validExtensions []string) bool {

--- a/check/file_extension.go
+++ b/check/file_extension.go
@@ -25,20 +25,16 @@ var ValidRegistryFileExtensions = []string{
 }
 
 func LegacyFileExtensionCheck(path string) error {
-	fileExtension := GetFileExtension(path)
-
-	if !IsValidLegacyFileExtension(fileExtension) {
-		return fmt.Errorf("invalid file extension (%s), valid values: %v", fileExtension, ValidLegacyFileExtensions)
+	if !FilePathEndsWithExtensionFrom(path, ValidLegacyFileExtensions) {
+		return fmt.Errorf("file does not end with a valid extension (%s), valid values: %v", GetFileExtension(path), ValidLegacyFileExtensions)
 	}
 
 	return nil
 }
 
 func RegistryFileExtensionCheck(path string) error {
-	fileExtension := GetFileExtension(path)
-
-	if !IsValidRegistryFileExtension(fileExtension) {
-		return fmt.Errorf("invalid file extension (%s), valid values: %v", fileExtension, ValidRegistryFileExtensions)
+	if !FilePathEndsWithExtensionFrom(path, ValidRegistryFileExtensions) {
+		return fmt.Errorf("file does not end with a valid extension (%s), valid values: %v", GetFileExtension(path), ValidLegacyFileExtensions)
 	}
 
 	return nil
@@ -62,19 +58,9 @@ func GetFileExtension(path string) string {
 	return filename
 }
 
-func IsValidLegacyFileExtension(fileExtension string) bool {
-	for _, validLegacyFileExtension := range ValidLegacyFileExtensions {
-		if fileExtension == validLegacyFileExtension {
-			return true
-		}
-	}
-
-	return false
-}
-
-func IsValidRegistryFileExtension(fileExtension string) bool {
-	for _, validRegistryFileExtension := range ValidRegistryFileExtensions {
-		if fileExtension == validRegistryFileExtension {
+func FilePathEndsWithExtensionFrom(path string, validExtensions []string) bool {
+	for _, validExtension := range validExtensions {
+		if strings.HasSuffix(path, validExtension) {
 			return true
 		}
 	}

--- a/check/file_extension_test.go
+++ b/check/file_extension_test.go
@@ -4,51 +4,6 @@ import (
 	"testing"
 )
 
-func TestGetFileExtension(t *testing.T) {
-	testCases := []struct {
-		Name   string
-		Path   string
-		Expect string
-	}{
-		{
-			Name:   "empty path",
-			Path:   "",
-			Expect: "",
-		},
-		{
-			Name:   "filename with single extension",
-			Path:   "file.md",
-			Expect: ".md",
-		},
-		{
-			Name:   "filename with multiple extensions",
-			Path:   "file.html.markdown",
-			Expect: ".html.markdown",
-		},
-		{
-			Name:   "full path with single extensions",
-			Path:   "docs/resource/thing.md",
-			Expect: ".md",
-		},
-		{
-			Name:   "full path with multiple extensions",
-			Path:   "website/docs/r/thing.html.markdown",
-			Expect: ".html.markdown",
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.Name, func(t *testing.T) {
-			got := GetFileExtension(testCase.Path)
-			want := testCase.Expect
-
-			if got != want {
-				t.Errorf("expected %s, got %s", want, got)
-			}
-		})
-	}
-}
-
 func TestTrimFileExtension(t *testing.T) {
 	testCases := []struct {
 		Name   string

--- a/check/legacy_guide_file_test.go
+++ b/check/legacy_guide_file_test.go
@@ -18,6 +18,11 @@ func TestLegacyGuideFileCheck(t *testing.T) {
 			Path:     "guide.html.markdown",
 		},
 		{
+			Name:     "valid",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "2.0-guide.html.markdown",
+		},
+		{
 			Name:        "invalid extension",
 			BasePath:    "testdata/invalid-legacy-files",
 			Path:        "guide_invalid_extension.txt",

--- a/check/registry_guide_file_test.go
+++ b/check/registry_guide_file_test.go
@@ -18,6 +18,11 @@ func TestRegistryGuideFileCheck(t *testing.T) {
 			Path:     "guide.md",
 		},
 		{
+			Name:     "valid",
+			BasePath: "testdata/valid-registry-files",
+			Path:     "2.0-guide.md",
+		},
+		{
 			Name:        "invalid extension",
 			BasePath:    "testdata/invalid-registry-files",
 			Path:        "guide_invalid_extension.markdown",

--- a/check/testdata/valid-legacy-files/2.0-guide.html.markdown
+++ b/check/testdata/valid-legacy-files/2.0-guide.html.markdown
@@ -1,0 +1,11 @@
+---
+subcategory: "Example"
+layout: "example"
+page_title: "Example Guide"
+description: |-
+  Example description.
+---
+
+# Example Guide
+
+Example contents.

--- a/check/testdata/valid-registry-files/2.0-guide.md
+++ b/check/testdata/valid-registry-files/2.0-guide.md
@@ -1,0 +1,10 @@
+---
+subcategory: "Example"
+page_title: "Example: example_thing"
+description: |-
+  Example description.
+---
+
+# Example Guide
+
+Example contents.


### PR DESCRIPTION
On the `azurerm` provider we have some guide names with `.`s in then: 
```
website/docs/guides/2.0-upgrade-guide.html.markdown: error checking file extension: invalid file extension (.0-upgrade-guide.html.markdown), valid values: [.html.markdown .html.md .markdown .md]
```

This PR changes the check to only ensure the path ends with a valid extension.