### PR TITLE
check: Prevent mixed Terraform Provider documentation directory layouts found error when using website/docs and docs/ contains files outside Terraform Provider documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.5.1
+
+BUG FIXES
+
+* check: Prevent `mixed Terraform Provider documentation directory layouts found` error when using `website/docs` and `docs/` contains files outside Terraform Provider documentation
+
 # v0.5.0
 
 ENHANCEMENTS

--- a/check/check_test.go
+++ b/check/check_test.go
@@ -20,6 +20,10 @@ func TestCheck(t *testing.T) {
 			BasePath: "testdata/valid-legacy-directories",
 		},
 		{
+			Name:     "valid mixed directories",
+			BasePath: "testdata/valid-mixed-directories",
+		},
+		{
 			Name:        "invalid directories",
 			BasePath:    "testdata/invalid-directories",
 			ExpectError: true,

--- a/check/directory.go
+++ b/check/directory.go
@@ -58,7 +58,8 @@ func MixedDirectoriesCheck(directories map[string][]string) error {
 	err := fmt.Errorf("mixed Terraform Provider documentation directory layouts found, must use only legacy or registry layout")
 
 	for directory := range directories {
-		if IsValidRegistryDirectory(directory) {
+		// Allow docs/ with other files
+		if IsValidRegistryDirectory(directory) && directory != RegistryIndexDirectory {
 			registryDirectoryFound = true
 
 			if legacyDirectoryFound {

--- a/check/testdata/valid-mixed-directories/website/docs/r/thing.html.markdown
+++ b/check/testdata/valid-mixed-directories/website/docs/r/thing.html.markdown
@@ -1,0 +1,27 @@
+---
+subcategory: "Example"
+layout: "example"
+page_title: "Example: example_thing"
+description: |-
+  Example description.
+---
+
+# Resource: example_thing
+
+Byline.
+
+## Example Usage
+
+```hcl
+resource "example_thing" "example" {
+  name = "example"
+}
+```
+
+## Argument Reference
+
+* `name` - (Required) Name of thing.
+
+## Attribute Reference
+
+* `id` - Name of thing.

--- a/version/version.go
+++ b/version/version.go
@@ -11,7 +11,7 @@ var (
 	GitDescribe string
 
 	// The main version number that is being run at the moment.
-	Version = "0.6.0"
+	Version = "0.5.1"
 
 	// A pre-release marker for the version. If this is "" (empty string)
 	// then it means that it is a final release. Otherwise, this is a pre-release


### PR DESCRIPTION
Closes #30