### PR TITLE
check: Add -ignore-file-(mismatch|missing)-(data-sources|resources) options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.6.0
+
+ENHANCEMENTS
+
+* check: Add `-ignore-file-mismatch-data-sources` option
+* check: Add `-ignore-file-mismatch-resources` option
+* check: Add `-ignore-file-missing-data-sources` option
+* check: Add `-ignore-file-missing-resources` option
+
 # v0.5.3
 
 BUG FIXES

--- a/check/file_mismatch.go
+++ b/check/file_mismatch.go
@@ -2,26 +2,79 @@ package check
 
 import (
 	"fmt"
+	"log"
 	"sort"
 
 	"github.com/hashicorp/go-multierror"
 	tfjson "github.com/hashicorp/terraform-json"
 )
 
-func ResourceFileMismatchCheck(providerName string, resourceType string, schemaResources map[string]*tfjson.Schema, files []string) error {
+type FileMismatchOptions struct {
+	*FileOptions
+
+	IgnoreFileMismatch []string
+
+	IgnoreFileMissing []string
+
+	ProviderName string
+
+	ResourceType string
+
+	Schemas map[string]*tfjson.Schema
+}
+
+type FileMismatchCheck struct {
+	Options *FileMismatchOptions
+}
+
+func NewFileMismatchCheck(opts *FileMismatchOptions) *FileMismatchCheck {
+	check := &FileMismatchCheck{
+		Options: opts,
+	}
+
+	if check.Options == nil {
+		check.Options = &FileMismatchOptions{}
+	}
+
+	if check.Options.FileOptions == nil {
+		check.Options.FileOptions = &FileOptions{}
+	}
+
+	return check
+}
+
+func (check *FileMismatchCheck) Run(files []string) error {
+	if len(files) == 0 {
+		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing file list", check.Options.ResourceType)
+		return nil
+	}
+
+	if len(check.Options.Schemas) == 0 {
+		log.Printf("[DEBUG] Skipping %s file mismatch checks due to missing schemas", check.Options.ResourceType)
+		return nil
+	}
+
 	var extraFiles []string
 	var missingFiles []string
 
 	for _, file := range files {
-		if fileHasResource(schemaResources, providerName, file) {
+		if fileHasResource(check.Options.Schemas, check.Options.ProviderName, file) {
+			continue
+		}
+
+		if check.IgnoreFileMismatch(file) {
 			continue
 		}
 
 		extraFiles = append(extraFiles, file)
 	}
 
-	for _, resourceName := range resourceNames(schemaResources) {
-		if resourceHasFile(files, providerName, resourceName) {
+	for _, resourceName := range resourceNames(check.Options.Schemas) {
+		if resourceHasFile(files, check.Options.ProviderName, resourceName) {
+			continue
+		}
+
+		if check.IgnoreFileMissing(resourceName) {
 			continue
 		}
 
@@ -31,16 +84,36 @@ func ResourceFileMismatchCheck(providerName string, resourceType string, schemaR
 	var result *multierror.Error
 
 	for _, extraFile := range extraFiles {
-		err := fmt.Errorf("matching %s for documentation file (%s) not found, file is extraneous or incorrectly named", resourceType, extraFile)
+		err := fmt.Errorf("matching %s for documentation file (%s) not found, file is extraneous or incorrectly named", check.Options.ResourceType, extraFile)
 		result = multierror.Append(result, err)
 	}
 
 	for _, missingFile := range missingFiles {
-		err := fmt.Errorf("missing documentation file for %s: %s", resourceType, missingFile)
+		err := fmt.Errorf("missing documentation file for %s: %s", check.Options.ResourceType, missingFile)
 		result = multierror.Append(result, err)
 	}
 
 	return result.ErrorOrNil()
+}
+
+func (check *FileMismatchCheck) IgnoreFileMismatch(file string) bool {
+	for _, ignoreResourceName := range check.Options.IgnoreFileMismatch {
+		if ignoreResourceName == fileResourceName(check.Options.ProviderName, file) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (check *FileMismatchCheck) IgnoreFileMissing(resourceName string) bool {
+	for _, ignoreResourceName := range check.Options.IgnoreFileMissing {
+		if ignoreResourceName == resourceName {
+			return true
+		}
+	}
+
+	return false
 }
 
 func fileHasResource(schemaResources map[string]*tfjson.Schema, providerName, file string) bool {


### PR DESCRIPTION
Allows providers with aliased data sources and resources or those with otherwise mismatched names to temporarily ignore the issues when using the `-providers-schema-json` option.

Verified with Terraform AWS Provider v2.61.0 via:

```console
$ tfproviderdocs check \
  -allowed-resource-subcategories-file website/allowed-subcategories.txt \
  -ignore-file-mismatch-resources aws_s3_bucket_analysis_configuration \
  -ignore-file-missing-data-sources aws_alb,aws_alb_listener,aws_alb_target_group \
  -ignore-file-missing-resources aws_alb,aws_alb_listener,aws_alb_listener_certificate,aws_alb_listener_rule,aws_alb_target_group,aws_alb_target_group_attachment,aws_s3_bucket_analytics_configuration \
  -ignore-side-navigation-data-sources aws_alb,aws_alb_listener,aws_alb_target_group,aws_kms_secret \
  -providers-schema-json=/Users/bflad/test/schema/aws.json \
  -require-resource-subcategory
```