### PR TITLE
check: Prefer `terraform` code block language over `hcl` in examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # v0.9.0
 
+BREAKING CHANGES
+
+* check: Prefer `terraform` code block language over `hcl` in examples with experimental `-enable-contents-check` flag
+
 ENHANCEMENTS
 
 * check: Add `-provider-source` option (support Terraform CLI 0.13 and later `-providers-schema-json` file)

--- a/check/contents/check_example_section.go
+++ b/check/contents/check_example_section.go
@@ -30,8 +30,8 @@ func (d *Document) checkExampleSection() error {
 	for _, fencedCodeBlock := range section.FencedCodeBlocks {
 		language := markdown.FencedCodeBlockLanguage(fencedCodeBlock, d.source)
 
-		if language != markdown.FencedCodeBlockLanguageHcl && language != markdown.FencedCodeBlockLanguageTerraform {
-			return fmt.Errorf("example section code block language (%s) should be: ```%s or ```%s", language, markdown.FencedCodeBlockLanguageHcl, markdown.FencedCodeBlockLanguageTerraform)
+		if language != markdown.FencedCodeBlockLanguageTerraform {
+			return fmt.Errorf("example section code block language (%s) should be: ```%s", language, markdown.FencedCodeBlockLanguageTerraform)
 		}
 
 		text := markdown.FencedCodeBlockText(fencedCodeBlock, d.source)

--- a/check/contents/testdata/example/missing_heading.md
+++ b/check/contents/testdata/example/missing_heading.md
@@ -1,6 +1,6 @@
 Manages an Example Thing.
 
-```hcl
+```terraform
 resource "test_missing_heading" "example" {
   name = "example"
 }

--- a/check/contents/testdata/example/passing.md
+++ b/check/contents/testdata/example/passing.md
@@ -1,6 +1,6 @@
 ## Example Usage
 
-```hcl
+```terraform
 resource "test_passing" "example" {
   name = "example"
 }

--- a/check/contents/testdata/example/wrong_code_block_language.md
+++ b/check/contents/testdata/example/wrong_code_block_language.md
@@ -1,6 +1,6 @@
 ## Example Usage
 
-```tf
+```hcl
 resource "test_wrong_code_block_language" "example" {
   name = "example"
 }

--- a/check/contents/testdata/example/wrong_heading_level.md
+++ b/check/contents/testdata/example/wrong_heading_level.md
@@ -1,6 +1,6 @@
 # Example Usage
 
-```hcl
+```terraform
 resource "test_wrong_heading_level" "example" {
   name = "example"
 }

--- a/check/contents/testdata/example/wrong_heading_text.md
+++ b/check/contents/testdata/example/wrong_heading_text.md
@@ -1,6 +1,6 @@
 ## Examples
 
-```hcl
+```terraform
 resource "test_wrong_heading_text" "example" {
   name = "example"
 }

--- a/check/contents/testdata/full.md
+++ b/check/contents/testdata/full.md
@@ -12,7 +12,7 @@ Manages a Test Full.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "test_full" "example" {
   name = "example"
 }

--- a/check/contents/testdata/title/missing_heading.md
+++ b/check/contents/testdata/title/missing_heading.md
@@ -2,7 +2,7 @@ Manages an Example Thing.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/contents/testdata/title/passing.md
+++ b/check/contents/testdata/title/passing.md
@@ -4,7 +4,7 @@ Manages an Example Thing.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-directories/website/docs/r/invalid/thing.html.markdown
+++ b/check/testdata/invalid-legacy-directories/website/docs/r/invalid/thing.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/data_source_invalid_extension.txt
+++ b/check/testdata/invalid-legacy-files/data_source_invalid_extension.txt
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/data_source_invalid_frontmatter.html.markdown
+++ b/check/testdata/invalid-legacy-files/data_source_invalid_frontmatter.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/data_source_with_sidebar_current.html.markdown
+++ b/check/testdata/invalid-legacy-files/data_source_with_sidebar_current.html.markdown
@@ -13,7 +13,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/data_source_without_layout.html.markdown
+++ b/check/testdata/invalid-legacy-files/data_source_without_layout.html.markdown
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/resource_invalid_extension.txt
+++ b/check/testdata/invalid-legacy-files/resource_invalid_extension.txt
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/resource_invalid_frontmatter.html.markdown
+++ b/check/testdata/invalid-legacy-files/resource_invalid_frontmatter.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/resource_with_sidebar_current.html.markdown
+++ b/check/testdata/invalid-legacy-files/resource_with_sidebar_current.html.markdown
@@ -13,7 +13,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-legacy-files/resource_without_layout.html.markdown
+++ b/check/testdata/invalid-legacy-files/resource_without_layout.html.markdown
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-mixed-directories/docs/resources/thing.md
+++ b/check/testdata/invalid-mixed-directories/docs/resources/thing.md
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-directories/docs/resources/invalid/thing.md
+++ b/check/testdata/invalid-registry-directories/docs/resources/invalid/thing.md
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/data_source_invalid_extension.markdown
+++ b/check/testdata/invalid-registry-files/data_source_invalid_extension.markdown
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/data_source_invalid_frontmatter.md
+++ b/check/testdata/invalid-registry-files/data_source_invalid_frontmatter.md
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/data_source_with_layout.md
+++ b/check/testdata/invalid-registry-files/data_source_with_layout.md
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/data_source_with_sidebar_current.md
+++ b/check/testdata/invalid-registry-files/data_source_with_sidebar_current.md
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/resource_invalid_extension.markdown
+++ b/check/testdata/invalid-registry-files/resource_invalid_extension.markdown
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/resource_invalid_frontmatter.md
+++ b/check/testdata/invalid-registry-files/resource_invalid_frontmatter.md
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/resource_with_layout.md
+++ b/check/testdata/invalid-registry-files/resource_with_layout.md
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/invalid-registry-files/resource_with_sidebar_current.md
+++ b/check/testdata/invalid-registry-files/resource_with_sidebar_current.md
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-legacy-directories/website/docs/d/thing.html.markdown
+++ b/check/testdata/valid-legacy-directories/website/docs/d/thing.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-legacy-directories/website/docs/r/thing.html.markdown
+++ b/check/testdata/valid-legacy-directories/website/docs/r/thing.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-legacy-files/data_source.html.markdown
+++ b/check/testdata/valid-legacy-files/data_source.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-legacy-files/resource.html.markdown
+++ b/check/testdata/valid-legacy-files/resource.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-mixed-directories/website/docs/r/thing.html.markdown
+++ b/check/testdata/valid-mixed-directories/website/docs/r/thing.html.markdown
@@ -12,7 +12,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-registry-directories/docs/data-sources/thing.md
+++ b/check/testdata/valid-registry-directories/docs/data-sources/thing.md
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-registry-directories/docs/resources/thing.md
+++ b/check/testdata/valid-registry-directories/docs/resources/thing.md
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-registry-files/data_source.md
+++ b/check/testdata/valid-registry-files/data_source.md
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 data "example_thing" "example" {
   name = "example"
 }

--- a/check/testdata/valid-registry-files/resource.md
+++ b/check/testdata/valid-registry-files/resource.md
@@ -11,7 +11,7 @@ Byline.
 
 ## Example Usage
 
-```hcl
+```terraform
 resource "example_thing" "example" {
   name = "example"
 }


### PR DESCRIPTION
Reference: https://github.com/bflad/tfproviderdocs/issues/21
Reference: https://github.com/hashicorp/terraform-provider-aws/issues/17810