### PR TITLE
check: Accept alternate attribute section byline of `No additional attributes are exported.`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v0.9.1
+
+BUG FIXES
+
+* check: Accept alternate attribute section byline of `No additional attributes are exported.` with experimental `-enable-contents-check` flag
+
 # v0.9.0
 
 BREAKING CHANGES

--- a/check/contents/check_attributes_section.go
+++ b/check/contents/check_attributes_section.go
@@ -36,16 +36,19 @@ func (d *Document) checkAttributesSection() error {
 	}
 
 	paragraphs := section.Paragraphs
-	expectedBylineText := "In addition to all arguments above, the following attributes are exported:"
+	expectedBylineTexts := []string{
+		"In addition to all arguments above, the following attributes are exported:",
+		"No additional attributes are exported.",
+	}
 
 	switch len(paragraphs) {
 	case 0:
-		return fmt.Errorf("attributes section byline should be: %s", expectedBylineText)
+		return fmt.Errorf("attributes section byline should be: %q or %q", expectedBylineTexts[0], expectedBylineTexts[1])
 	case 1:
 		paragraphText := string(paragraphs[0].Text(d.source))
 
-		if paragraphText != expectedBylineText {
-			return fmt.Errorf("attributes section byline (%s) should be: %s", paragraphText, expectedBylineText)
+		if paragraphText != expectedBylineTexts[0] && paragraphText != expectedBylineTexts[1] {
+			return fmt.Errorf("attributes section byline (%s) should be: %q or %q", paragraphText, expectedBylineTexts[0], expectedBylineTexts[1])
 		}
 	}
 

--- a/check/contents/check_attributes_section_test.go
+++ b/check/contents/check_attributes_section_test.go
@@ -18,6 +18,11 @@ func TestCheckAttributesSection(t *testing.T) {
 			ProviderName: "test",
 		},
 		{
+			Name:         "passing alternate byline",
+			Path:         "testdata/attributes/passing_alternate_byline.md",
+			ProviderName: "test",
+		},
+		{
 			Name:         "missing byline",
 			Path:         "testdata/attributes/missing_byline.md",
 			ProviderName: "test",

--- a/check/contents/testdata/attributes/passing_alternate_byline.md
+++ b/check/contents/testdata/attributes/passing_alternate_byline.md
@@ -1,0 +1,3 @@
+## Attributes Reference
+
+No additional attributes are exported.


### PR DESCRIPTION
Closes #43