### PR TITLE
check: make cdktf checks optional

### DIFF
--- a/check/check.go
+++ b/check/check.go
@@ -102,26 +102,28 @@ func (check *Check) Run(directories map[string][]string) error {
 		}
 	}
 
-	if check.Options.EnableCdktfCheck {
-		for _, cdktfLanguage := range ValidCdktfLanguages {
-			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryDataSourcesDirectory)]; ok {
+	for _, cdktfLanguage := range ValidCdktfLanguages {
+		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryDataSourcesDirectory)]; ok {
+			if check.Options.EnableCdktfCheck {
 				if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
-					result = multierror.Append(result, err)
-				}
-
-				if err := NewRegistryDataSourceFileCheck(check.Options.RegistryDataSourceFile).RunAll(files); err != nil {
 					result = multierror.Append(result, err)
 				}
 			}
 
-			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryResourcesDirectory)]; ok {
+			if err := NewRegistryDataSourceFileCheck(check.Options.RegistryDataSourceFile).RunAll(files); err != nil {
+				result = multierror.Append(result, err)
+			}
+		}
+
+		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryResourcesDirectory)]; ok {
+			if check.Options.EnableCdktfCheck {
 				if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
 					result = multierror.Append(result, err)
 				}
+			}
 
-				if err := NewRegistryResourceFileCheck(check.Options.RegistryResourceFile).RunAll(files, cdktfLanguage); err != nil {
-					result = multierror.Append(result, err)
-				}
+			if err := NewRegistryResourceFileCheck(check.Options.RegistryResourceFile).RunAll(files, cdktfLanguage); err != nil {
+				result = multierror.Append(result, err)
 			}
 		}
 	}
@@ -161,26 +163,28 @@ func (check *Check) Run(directories map[string][]string) error {
 		}
 	}
 
-	if check.Options.EnableCdktfCheck {
-		for _, cdktfLanguage := range ValidCdktfLanguages {
-			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyDataSourcesDirectory)]; ok {
+	for _, cdktfLanguage := range ValidCdktfLanguages {
+		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyDataSourcesDirectory)]; ok {
+			if check.Options.EnableCdktfCheck {
 				if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
-					result = multierror.Append(result, err)
-				}
-
-				if err := NewLegacyDataSourceFileCheck(check.Options.LegacyDataSourceFile).RunAll(files); err != nil {
 					result = multierror.Append(result, err)
 				}
 			}
 
-			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyResourcesDirectory)]; ok {
+			if err := NewLegacyDataSourceFileCheck(check.Options.LegacyDataSourceFile).RunAll(files); err != nil {
+				result = multierror.Append(result, err)
+			}
+		}
+
+		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyResourcesDirectory)]; ok {
+			if check.Options.EnableCdktfCheck {
 				if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
 					result = multierror.Append(result, err)
 				}
+			}
 
-				if err := NewLegacyResourceFileCheck(check.Options.LegacyResourceFile).RunAll(files, cdktfLanguage); err != nil {
-					result = multierror.Append(result, err)
-				}
+			if err := NewLegacyResourceFileCheck(check.Options.LegacyResourceFile).RunAll(files, cdktfLanguage); err != nil {
+				result = multierror.Append(result, err)
 			}
 		}
 	}

--- a/check/check.go
+++ b/check/check.go
@@ -39,6 +39,8 @@ type CheckOptions struct {
 	RegistryResourceFile   *RegistryResourceFileOptions
 
 	ResourceFileMismatch *FileMismatchOptions
+
+	EnableCdktfCheck bool
 }
 
 func NewCheck(opts *CheckOptions) *Check {
@@ -100,24 +102,26 @@ func (check *Check) Run(directories map[string][]string) error {
 		}
 	}
 
-	for _, cdktfLanguage := range ValidCdktfLanguages {
-		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryDataSourcesDirectory)]; ok {
-			if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
-				result = multierror.Append(result, err)
+	if check.Options.EnableCdktfCheck {
+		for _, cdktfLanguage := range ValidCdktfLanguages {
+			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryDataSourcesDirectory)]; ok {
+				if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
+					result = multierror.Append(result, err)
+				}
+
+				if err := NewRegistryDataSourceFileCheck(check.Options.RegistryDataSourceFile).RunAll(files); err != nil {
+					result = multierror.Append(result, err)
+				}
 			}
 
-			if err := NewRegistryDataSourceFileCheck(check.Options.RegistryDataSourceFile).RunAll(files); err != nil {
-				result = multierror.Append(result, err)
-			}
-		}
+			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryResourcesDirectory)]; ok {
+				if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
+					result = multierror.Append(result, err)
+				}
 
-		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryResourcesDirectory)]; ok {
-			if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
-				result = multierror.Append(result, err)
-			}
-
-			if err := NewRegistryResourceFileCheck(check.Options.RegistryResourceFile).RunAll(files, cdktfLanguage); err != nil {
-				result = multierror.Append(result, err)
+				if err := NewRegistryResourceFileCheck(check.Options.RegistryResourceFile).RunAll(files, cdktfLanguage); err != nil {
+					result = multierror.Append(result, err)
+				}
 			}
 		}
 	}
@@ -157,24 +161,26 @@ func (check *Check) Run(directories map[string][]string) error {
 		}
 	}
 
-	for _, cdktfLanguage := range ValidCdktfLanguages {
-		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyDataSourcesDirectory)]; ok {
-			if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
-				result = multierror.Append(result, err)
+	if check.Options.EnableCdktfCheck {
+		for _, cdktfLanguage := range ValidCdktfLanguages {
+			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyDataSourcesDirectory)]; ok {
+				if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
+					result = multierror.Append(result, err)
+				}
+
+				if err := NewLegacyDataSourceFileCheck(check.Options.LegacyDataSourceFile).RunAll(files); err != nil {
+					result = multierror.Append(result, err)
+				}
 			}
 
-			if err := NewLegacyDataSourceFileCheck(check.Options.LegacyDataSourceFile).RunAll(files); err != nil {
-				result = multierror.Append(result, err)
-			}
-		}
+			if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyResourcesDirectory)]; ok {
+				if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
+					result = multierror.Append(result, err)
+				}
 
-		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyResourcesDirectory)]; ok {
-			if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
-				result = multierror.Append(result, err)
-			}
-
-			if err := NewLegacyResourceFileCheck(check.Options.LegacyResourceFile).RunAll(files, cdktfLanguage); err != nil {
-				result = multierror.Append(result, err)
+				if err := NewLegacyResourceFileCheck(check.Options.LegacyResourceFile).RunAll(files, cdktfLanguage); err != nil {
+					result = multierror.Append(result, err)
+				}
 			}
 		}
 	}

--- a/check/check.go
+++ b/check/check.go
@@ -40,7 +40,7 @@ type CheckOptions struct {
 
 	ResourceFileMismatch *FileMismatchOptions
 
-	EnableCdktfCheck bool
+	IgnoreCdktfMissingFiles bool
 }
 
 func NewCheck(opts *CheckOptions) *Check {
@@ -104,7 +104,7 @@ func (check *Check) Run(directories map[string][]string) error {
 
 	for _, cdktfLanguage := range ValidCdktfLanguages {
 		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryDataSourcesDirectory)]; ok {
-			if check.Options.EnableCdktfCheck {
+			if !check.Options.IgnoreCdktfMissingFiles {
 				if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
 					result = multierror.Append(result, err)
 				}
@@ -116,7 +116,7 @@ func (check *Check) Run(directories map[string][]string) error {
 		}
 
 		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", RegistryIndexDirectory, CdktfIndexDirectory, cdktfLanguage, RegistryResourcesDirectory)]; ok {
-			if check.Options.EnableCdktfCheck {
+			if !check.Options.IgnoreCdktfMissingFiles {
 				if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
 					result = multierror.Append(result, err)
 				}
@@ -165,7 +165,7 @@ func (check *Check) Run(directories map[string][]string) error {
 
 	for _, cdktfLanguage := range ValidCdktfLanguages {
 		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyDataSourcesDirectory)]; ok {
-			if check.Options.EnableCdktfCheck {
+			if !check.Options.IgnoreCdktfMissingFiles {
 				if err := NewFileMismatchCheck(check.Options.DataSourceFileMismatch).Run(files); err != nil {
 					result = multierror.Append(result, err)
 				}
@@ -177,7 +177,7 @@ func (check *Check) Run(directories map[string][]string) error {
 		}
 
 		if files, ok := directories[fmt.Sprintf("%s/%s/%s/%s", LegacyIndexDirectory, CdktfIndexDirectory, cdktfLanguage, LegacyResourcesDirectory)]; ok {
-			if check.Options.EnableCdktfCheck {
+			if !check.Options.IgnoreCdktfMissingFiles {
 				if err := NewFileMismatchCheck(check.Options.ResourceFileMismatch).Run(files); err != nil {
 					result = multierror.Append(result, err)
 				}

--- a/command/check.go
+++ b/command/check.go
@@ -24,7 +24,7 @@ type CheckCommandConfig struct {
 	AllowedResourceSubcategories     string
 	AllowedResourceSubcategoriesFile string
 	EnableContentsCheck              bool
-	EnableCdktfCheck                 bool
+	IgnoreCdktfMissingFiles          bool
 	IgnoreFileMismatchDataSources    string
 	IgnoreFileMismatchResources      string
 	IgnoreFileMissingDataSources     string
@@ -53,7 +53,7 @@ func (*CheckCommand) Help() string {
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-allowed-resource-subcategories", "Comma separated list of allowed data source and resource frontmatter subcategories.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-allowed-resource-subcategories-file", "Path to newline separated file of allowed data source and resource frontmatter subcategories.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-enable-contents-check", "(Experimental) Enable contents checking.")
-	fmt.Fprintf(opts, CommandHelpOptionFormat, "-enable-cdktf-check", "Enable checking for CDK for Terraform docs.")
+	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-cdktf-missing-files", "Ignore checks for CDK for Terraform docs.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-mismatch-data-sources", "Comma separated list of data sources to ignore mismatched/extra files.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-mismatch-resources", "Comma separated list of resources to ignore mismatched/extra files.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-missing-data-sources", "Comma separated list of data sources to ignore missing files.")
@@ -92,7 +92,7 @@ func (c *CheckCommand) Run(args []string) int {
 	flags.StringVar(&config.AllowedResourceSubcategories, "allowed-resource-subcategories", "", "")
 	flags.StringVar(&config.AllowedResourceSubcategoriesFile, "allowed-resource-subcategories-file", "", "")
 	flags.BoolVar(&config.EnableContentsCheck, "enable-contents-check", false, "")
-	flags.BoolVar(&config.EnableCdktfCheck, "enable-cdktf-check", false, "")
+	flags.BoolVar(&config.IgnoreCdktfMissingFiles, "ignore-cdktf-missing-files", false, "")
 	flags.StringVar(&config.IgnoreFileMismatchDataSources, "ignore-file-mismatch-data-sources", "", "")
 	flags.StringVar(&config.IgnoreFileMismatchResources, "ignore-file-mismatch-resources", "", "")
 	flags.StringVar(&config.IgnoreFileMissingDataSources, "ignore-file-missing-data-sources", "", "")
@@ -302,7 +302,7 @@ Check that the current working directory or provided path is prefixed with terra
 			ResourceType:       check.ResourceTypeResource,
 			Schemas:            schemaResources,
 		},
-		EnableCdktfCheck: config.EnableCdktfCheck,
+		IgnoreCdktfMissingFiles: config.IgnoreCdktfMissingFiles,
 	}
 
 	if err := check.NewCheck(checkOpts).Run(directories); err != nil {

--- a/command/check.go
+++ b/command/check.go
@@ -24,6 +24,7 @@ type CheckCommandConfig struct {
 	AllowedResourceSubcategories     string
 	AllowedResourceSubcategoriesFile string
 	EnableContentsCheck              bool
+	EnableCdktfCheck                 bool
 	IgnoreFileMismatchDataSources    string
 	IgnoreFileMismatchResources      string
 	IgnoreFileMissingDataSources     string
@@ -52,6 +53,7 @@ func (*CheckCommand) Help() string {
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-allowed-resource-subcategories", "Comma separated list of allowed data source and resource frontmatter subcategories.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-allowed-resource-subcategories-file", "Path to newline separated file of allowed data source and resource frontmatter subcategories.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-enable-contents-check", "(Experimental) Enable contents checking.")
+	fmt.Fprintf(opts, CommandHelpOptionFormat, "-enable-cdktf-check", "Enable checking for CDK for Terraform docs.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-mismatch-data-sources", "Comma separated list of data sources to ignore mismatched/extra files.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-mismatch-resources", "Comma separated list of resources to ignore mismatched/extra files.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-missing-data-sources", "Comma separated list of data sources to ignore missing files.")
@@ -90,6 +92,7 @@ func (c *CheckCommand) Run(args []string) int {
 	flags.StringVar(&config.AllowedResourceSubcategories, "allowed-resource-subcategories", "", "")
 	flags.StringVar(&config.AllowedResourceSubcategoriesFile, "allowed-resource-subcategories-file", "", "")
 	flags.BoolVar(&config.EnableContentsCheck, "enable-contents-check", false, "")
+	flags.BoolVar(&config.EnableCdktfCheck, "enable-cdktf-check", false, "")
 	flags.StringVar(&config.IgnoreFileMismatchDataSources, "ignore-file-mismatch-data-sources", "", "")
 	flags.StringVar(&config.IgnoreFileMismatchResources, "ignore-file-mismatch-resources", "", "")
 	flags.StringVar(&config.IgnoreFileMissingDataSources, "ignore-file-missing-data-sources", "", "")
@@ -299,6 +302,7 @@ Check that the current working directory or provided path is prefixed with terra
 			ResourceType:       check.ResourceTypeResource,
 			Schemas:            schemaResources,
 		},
+		EnableCdktfCheck: config.EnableCdktfCheck,
 	}
 
 	if err := check.NewCheck(checkOpts).Run(directories); err != nil {

--- a/command/check.go
+++ b/command/check.go
@@ -53,7 +53,7 @@ func (*CheckCommand) Help() string {
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-allowed-resource-subcategories", "Comma separated list of allowed data source and resource frontmatter subcategories.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-allowed-resource-subcategories-file", "Path to newline separated file of allowed data source and resource frontmatter subcategories.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-enable-contents-check", "(Experimental) Enable contents checking.")
-	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-cdktf-missing-files", "Ignore checks for CDK for Terraform docs.")
+	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-cdktf-missing-files", "Ignore checks for missing CDK for Terraform documentation files when iteratively introducing them in large providers.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-mismatch-data-sources", "Comma separated list of data sources to ignore mismatched/extra files.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-mismatch-resources", "Comma separated list of resources to ignore mismatched/extra files.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-ignore-file-missing-data-sources", "Comma separated list of data sources to ignore missing files.")


### PR DESCRIPTION
Our current rollout process for cdktf docs is gradual, therefore we want to merge PRs with only a few resources at a time so the PRs stay reviewable for bigger providers. Therefore we need to make this check optional, so we can enable it once all PRs are merged.