### PR TITLE
Add `-warn-deprecated-features` and `-require-layout` flags, change tool to allow legacy files not contain `layout` frontmatter as default

### DIFF
--- a/check/frontmatter.go
+++ b/check/frontmatter.go
@@ -21,16 +21,17 @@ type FrontMatterData struct {
 
 // FrontMatterOptions represents configuration options for FrontMatter.
 type FrontMatterOptions struct {
-	AllowedSubcategories []string
-	NoDescription        bool
-	NoLayout             bool
-	NoPageTitle          bool
-	NoSidebarCurrent     bool
-	NoSubcategory        bool
-	RequireDescription   bool
-	RequireLayout        bool
-	RequirePageTitle     bool
-	RequireSubcategory   bool
+	AllowedSubcategories   []string
+	NoDescription          bool
+	NoLayout               bool
+	NoPageTitle            bool
+	NoSidebarCurrent       bool
+	NoSubcategory          bool
+	RequireDescription     bool
+	RequireLayout          bool
+	RequirePageTitle       bool
+	RequireSubcategory     bool
+	WarnDeprecatedFeatures bool
 }
 
 func NewFrontMatterCheck(opts *FrontMatterOptions) *FrontMatterCheck {
@@ -79,6 +80,10 @@ func (check *FrontMatterCheck) Run(src []byte) error {
 
 	if check.Options.RequireLayout && frontMatter.Layout == nil {
 		return fmt.Errorf("YAML frontmatter missing required layout")
+	}
+
+	if check.Options.WarnDeprecatedFeatures && frontMatter.Layout != nil {
+		return fmt.Errorf("YAML frontmatter contains deprecated layout- this can be removed")
 	}
 
 	if check.Options.RequirePageTitle && frontMatter.PageTitle == nil {

--- a/check/frontmatter_test.go
+++ b/check/frontmatter_test.go
@@ -197,6 +197,20 @@ page_title: Example Page Title
 			},
 			ExpectError: true,
 		},
+		{
+			Name: "warn about deprecated layout frontmatter in valid file (-warn-deprecated-features flag)",
+			Source: `
+description: |-
+  Example description
+layout: "example"
+page_title: Example Page Title
+subcategory: Example Subcategory
+`,
+			Options: &FrontMatterOptions{
+				WarnDeprecatedFeatures: true,
+			},
+			ExpectError: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_data_source_file.go
+++ b/check/legacy_data_source_file.go
@@ -39,12 +39,7 @@ func NewLegacyDataSourceFileCheck(opts *LegacyDataSourceFileOptions) *LegacyData
 
 	check.Options.FrontMatter.NoSidebarCurrent = true
 	check.Options.FrontMatter.RequireDescription = true
-	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
-
-	if check.Options.FrontMatter.WarnDeprecatedFeatures {
-		check.Options.FrontMatter.RequireLayout = false
-	}
 
 	return check
 }

--- a/check/legacy_data_source_file.go
+++ b/check/legacy_data_source_file.go
@@ -42,6 +42,10 @@ func NewLegacyDataSourceFileCheck(opts *LegacyDataSourceFileOptions) *LegacyData
 	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
 
+	if check.Options.FrontMatter.WarnDeprecatedFeatures {
+		check.Options.FrontMatter.RequireLayout = false
+	}
+
 	return check
 }
 

--- a/check/legacy_data_source_file_test.go
+++ b/check/legacy_data_source_file_test.go
@@ -41,6 +41,17 @@ func TestLegacyDataSourceFileCheck(t *testing.T) {
 			Path:        "data_source_without_layout.html.markdown",
 			ExpectError: true,
 		},
+		{
+			Name:     "warn about frontmatter deprecated layout",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "data_source.html.markdown",
+			Options: &LegacyDataSourceFileOptions{
+				FrontMatter: &FrontMatterOptions{
+					WarnDeprecatedFeatures: true,
+				},
+			},
+			ExpectError: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_data_source_file_test.go
+++ b/check/legacy_data_source_file_test.go
@@ -41,17 +41,6 @@ func TestLegacyDataSourceFileCheck(t *testing.T) {
 			Path:        "data_source_without_layout.html.markdown",
 			ExpectError: true,
 		},
-		{
-			Name:     "warn about frontmatter deprecated layout",
-			BasePath: "testdata/valid-legacy-files",
-			Path:     "data_source.html.markdown",
-			Options: &LegacyDataSourceFileOptions{
-				FrontMatter: &FrontMatterOptions{
-					WarnDeprecatedFeatures: true,
-				},
-			},
-			ExpectError: true,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_data_source_file_test.go
+++ b/check/legacy_data_source_file_test.go
@@ -18,6 +18,11 @@ func TestLegacyDataSourceFileCheck(t *testing.T) {
 			Path:     "data_source.html.markdown",
 		},
 		{
+			Name:     "valid frontmatter without layout",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "data_source_without_layout.html.markdown",
+		},
+		{
 			Name:        "invalid extension",
 			BasePath:    "testdata/invalid-legacy-files",
 			Path:        "data_source_invalid_extension.txt",
@@ -33,12 +38,6 @@ func TestLegacyDataSourceFileCheck(t *testing.T) {
 			Name:        "invalid frontmatter with sidebar_current",
 			BasePath:    "testdata/invalid-legacy-files",
 			Path:        "data_source_with_sidebar_current.html.markdown",
-			ExpectError: true,
-		},
-		{
-			Name:        "invalid frontmatter without layout",
-			BasePath:    "testdata/invalid-legacy-files",
-			Path:        "data_source_without_layout.html.markdown",
 			ExpectError: true,
 		},
 	}

--- a/check/legacy_guide_file.go
+++ b/check/legacy_guide_file.go
@@ -39,12 +39,7 @@ func NewLegacyGuideFileCheck(opts *LegacyGuideFileOptions) *LegacyGuideFileCheck
 
 	check.Options.FrontMatter.NoSidebarCurrent = true
 	check.Options.FrontMatter.RequireDescription = true
-	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
-
-	if check.Options.FrontMatter.WarnDeprecatedFeatures {
-		check.Options.FrontMatter.RequireLayout = false
-	}
 
 	return check
 }

--- a/check/legacy_guide_file.go
+++ b/check/legacy_guide_file.go
@@ -42,6 +42,10 @@ func NewLegacyGuideFileCheck(opts *LegacyGuideFileOptions) *LegacyGuideFileCheck
 	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
 
+	if check.Options.FrontMatter.WarnDeprecatedFeatures {
+		check.Options.FrontMatter.RequireLayout = false
+	}
+
 	return check
 }
 

--- a/check/legacy_guide_file_test.go
+++ b/check/legacy_guide_file_test.go
@@ -46,6 +46,17 @@ func TestLegacyGuideFileCheck(t *testing.T) {
 			Path:        "guide_without_layout.html.markdown",
 			ExpectError: true,
 		},
+		{
+			Name:     "warn about frontmatter deprecated layout",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "guide.html.markdown",
+			Options: &LegacyGuideFileOptions{
+				FrontMatter: &FrontMatterOptions{
+					WarnDeprecatedFeatures: true,
+				},
+			},
+			ExpectError: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_guide_file_test.go
+++ b/check/legacy_guide_file_test.go
@@ -46,17 +46,6 @@ func TestLegacyGuideFileCheck(t *testing.T) {
 			Path:        "guide_without_layout.html.markdown",
 			ExpectError: true,
 		},
-		{
-			Name:     "warn about frontmatter deprecated layout",
-			BasePath: "testdata/valid-legacy-files",
-			Path:     "guide.html.markdown",
-			Options: &LegacyGuideFileOptions{
-				FrontMatter: &FrontMatterOptions{
-					WarnDeprecatedFeatures: true,
-				},
-			},
-			ExpectError: true,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_guide_file_test.go
+++ b/check/legacy_guide_file_test.go
@@ -23,6 +23,11 @@ func TestLegacyGuideFileCheck(t *testing.T) {
 			Path:     "2.0-guide.html.markdown",
 		},
 		{
+			Name:     "valid frontmatter without layout",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "guide_without_layout.html.markdown",
+		},
+		{
 			Name:        "invalid extension",
 			BasePath:    "testdata/invalid-legacy-files",
 			Path:        "guide_invalid_extension.txt",
@@ -38,12 +43,6 @@ func TestLegacyGuideFileCheck(t *testing.T) {
 			Name:        "invalid frontmatter with sidebar_current",
 			BasePath:    "testdata/invalid-legacy-files",
 			Path:        "guide_with_sidebar_current.html.markdown",
-			ExpectError: true,
-		},
-		{
-			Name:        "invalid frontmatter without layout",
-			BasePath:    "testdata/invalid-legacy-files",
-			Path:        "guide_without_layout.html.markdown",
 			ExpectError: true,
 		},
 	}

--- a/check/legacy_index_file.go
+++ b/check/legacy_index_file.go
@@ -43,6 +43,10 @@ func NewLegacyIndexFileCheck(opts *LegacyIndexFileOptions) *LegacyIndexFileCheck
 	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
 
+	if check.Options.FrontMatter.WarnDeprecatedFeatures {
+		check.Options.FrontMatter.RequireLayout = false
+	}
+
 	return check
 }
 

--- a/check/legacy_index_file.go
+++ b/check/legacy_index_file.go
@@ -40,12 +40,7 @@ func NewLegacyIndexFileCheck(opts *LegacyIndexFileOptions) *LegacyIndexFileCheck
 	check.Options.FrontMatter.NoSidebarCurrent = true
 	check.Options.FrontMatter.NoSubcategory = true
 	check.Options.FrontMatter.RequireDescription = true
-	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
-
-	if check.Options.FrontMatter.WarnDeprecatedFeatures {
-		check.Options.FrontMatter.RequireLayout = false
-	}
 
 	return check
 }

--- a/check/legacy_index_file_test.go
+++ b/check/legacy_index_file_test.go
@@ -47,6 +47,17 @@ func TestLegacyIndexFileCheck(t *testing.T) {
 			Path:        "index_without_layout.html.markdown",
 			ExpectError: true,
 		},
+		{
+			Name:     "warn about frontmatter deprecated layout",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "index.html.markdown",
+			Options: &LegacyIndexFileOptions{
+				FrontMatter: &FrontMatterOptions{
+					WarnDeprecatedFeatures: true,
+				},
+			},
+			ExpectError: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_index_file_test.go
+++ b/check/legacy_index_file_test.go
@@ -47,17 +47,6 @@ func TestLegacyIndexFileCheck(t *testing.T) {
 			Path:        "index_without_layout.html.markdown",
 			ExpectError: true,
 		},
-		{
-			Name:     "warn about frontmatter deprecated layout",
-			BasePath: "testdata/valid-legacy-files",
-			Path:     "index.html.markdown",
-			Options: &LegacyIndexFileOptions{
-				FrontMatter: &FrontMatterOptions{
-					WarnDeprecatedFeatures: true,
-				},
-			},
-			ExpectError: true,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_index_file_test.go
+++ b/check/legacy_index_file_test.go
@@ -18,6 +18,11 @@ func TestLegacyIndexFileCheck(t *testing.T) {
 			Path:     "index.html.markdown",
 		},
 		{
+			Name:     "valid frontmatter without layout",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "index_without_layout.html.markdown",
+		},
+		{
 			Name:        "invalid extension",
 			BasePath:    "testdata/invalid-legacy-files",
 			Path:        "index_invalid_extension.txt",
@@ -39,12 +44,6 @@ func TestLegacyIndexFileCheck(t *testing.T) {
 			Name:        "invalid frontmatter with sidebar_current",
 			BasePath:    "testdata/invalid-legacy-files",
 			Path:        "index_with_sidebar_current.html.markdown",
-			ExpectError: true,
-		},
-		{
-			Name:        "invalid frontmatter without layout",
-			BasePath:    "testdata/invalid-legacy-files",
-			Path:        "index_without_layout.html.markdown",
 			ExpectError: true,
 		},
 	}

--- a/check/legacy_resource_file.go
+++ b/check/legacy_resource_file.go
@@ -52,6 +52,10 @@ func NewLegacyResourceFileCheck(opts *LegacyResourceFileOptions) *LegacyResource
 	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
 
+	if check.Options.FrontMatter.WarnDeprecatedFeatures {
+		check.Options.FrontMatter.RequireLayout = false
+	}
+
 	return check
 }
 

--- a/check/legacy_resource_file.go
+++ b/check/legacy_resource_file.go
@@ -49,12 +49,7 @@ func NewLegacyResourceFileCheck(opts *LegacyResourceFileOptions) *LegacyResource
 
 	check.Options.FrontMatter.NoSidebarCurrent = true
 	check.Options.FrontMatter.RequireDescription = true
-	check.Options.FrontMatter.RequireLayout = true
 	check.Options.FrontMatter.RequirePageTitle = true
-
-	if check.Options.FrontMatter.WarnDeprecatedFeatures {
-		check.Options.FrontMatter.RequireLayout = false
-	}
 
 	return check
 }

--- a/check/legacy_resource_file_test.go
+++ b/check/legacy_resource_file_test.go
@@ -47,6 +47,17 @@ func TestLegacyResourceFileCheck(t *testing.T) {
 			ExampleLanguage: "terraform",
 			ExpectError:     true,
 		},
+		{
+			Name:     "warn about frontmatter deprecated layout",
+			BasePath: "testdata/valid-legacy-files",
+			Path:     "index.html.markdown",
+			Options: &LegacyResourceFileOptions{
+				FrontMatter: &FrontMatterOptions{
+					WarnDeprecatedFeatures: true,
+				},
+			},
+			ExpectError: true,
+		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_resource_file_test.go
+++ b/check/legacy_resource_file_test.go
@@ -47,17 +47,6 @@ func TestLegacyResourceFileCheck(t *testing.T) {
 			ExampleLanguage: "terraform",
 			ExpectError:     true,
 		},
-		{
-			Name:     "warn about frontmatter deprecated layout",
-			BasePath: "testdata/valid-legacy-files",
-			Path:     "index.html.markdown",
-			Options: &LegacyResourceFileOptions{
-				FrontMatter: &FrontMatterOptions{
-					WarnDeprecatedFeatures: true,
-				},
-			},
-			ExpectError: true,
-		},
 	}
 
 	for _, testCase := range testCases {

--- a/check/legacy_resource_file_test.go
+++ b/check/legacy_resource_file_test.go
@@ -20,6 +20,12 @@ func TestLegacyResourceFileCheck(t *testing.T) {
 			ExampleLanguage: "terraform",
 		},
 		{
+			Name:            "valid frontmatter without layout",
+			BasePath:        "testdata/valid-legacy-files",
+			Path:            "resource_without_layout.html.markdown",
+			ExampleLanguage: "terraform",
+		},
+		{
 			Name:            "invalid extension",
 			BasePath:        "testdata/invalid-legacy-files",
 			Path:            "resource_invalid_extension.txt",
@@ -37,13 +43,6 @@ func TestLegacyResourceFileCheck(t *testing.T) {
 			Name:            "invalid frontmatter with sidebar_current",
 			BasePath:        "testdata/invalid-legacy-files",
 			Path:            "resource_with_sidebar_current.html.markdown",
-			ExampleLanguage: "terraform",
-			ExpectError:     true,
-		},
-		{
-			Name:            "invalid frontmatter without layout",
-			BasePath:        "testdata/invalid-legacy-files",
-			Path:            "resource_without_layout.html.markdown",
 			ExampleLanguage: "terraform",
 			ExpectError:     true,
 		},

--- a/command/check.go
+++ b/command/check.go
@@ -37,6 +37,7 @@ type CheckCommandConfig struct {
 	RequireGuideSubcategory          bool
 	RequireResourceSubcategory       bool
 	RequireSchemaOrdering            bool
+	WarnDeprecatedFeatures           bool
 }
 
 // CheckCommand is a Command implementation
@@ -64,6 +65,7 @@ func (*CheckCommand) Help() string {
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-require-guide-subcategory", "Require guide frontmatter subcategory.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-require-resource-subcategory", "Require data source and resource frontmatter subcategory.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-require-schema-ordering", "Require schema attribute lists to be alphabetically ordered (requires -enable-contents-check).")
+	fmt.Fprintf(opts, CommandHelpOptionFormat, "-warn-deprecated-features", "Warn about deprecated frontmatter and files that can be removed.")
 	opts.Flush()
 
 	helpText := fmt.Sprintf(`
@@ -103,6 +105,7 @@ func (c *CheckCommand) Run(args []string) int {
 	flags.BoolVar(&config.RequireGuideSubcategory, "require-guide-subcategory", false, "")
 	flags.BoolVar(&config.RequireResourceSubcategory, "require-resource-subcategory", false, "")
 	flags.BoolVar(&config.RequireSchemaOrdering, "require-schema-ordering", false, "")
+	flags.BoolVar(&config.WarnDeprecatedFeatures, "warn-deprecated-features", false, "")
 
 	if err := flags.Parse(args); err != nil {
 		flags.Usage()
@@ -238,15 +241,17 @@ Check that the current working directory or provided path is prefixed with terra
 		LegacyDataSourceFile: &check.LegacyDataSourceFileOptions{
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
-				AllowedSubcategories: allowedResourceSubcategories,
-				RequireSubcategory:   config.RequireResourceSubcategory,
+				AllowedSubcategories:   allowedResourceSubcategories,
+				RequireSubcategory:     config.RequireResourceSubcategory,
+				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
 		},
 		LegacyGuideFile: &check.LegacyGuideFileOptions{
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
-				AllowedSubcategories: allowedGuideSubcategories,
-				RequireSubcategory:   config.RequireGuideSubcategory,
+				AllowedSubcategories:   allowedGuideSubcategories,
+				RequireSubcategory:     config.RequireGuideSubcategory,
+				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
 		},
 		LegacyIndexFile: &check.LegacyIndexFileOptions{
@@ -259,8 +264,9 @@ Check that the current working directory or provided path is prefixed with terra
 			},
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
-				AllowedSubcategories: allowedResourceSubcategories,
-				RequireSubcategory:   config.RequireResourceSubcategory,
+				AllowedSubcategories:   allowedResourceSubcategories,
+				RequireSubcategory:     config.RequireResourceSubcategory,
+				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
 			ProviderName: config.ProviderName,
 		},
@@ -269,15 +275,17 @@ Check that the current working directory or provided path is prefixed with terra
 		RegistryDataSourceFile: &check.RegistryDataSourceFileOptions{
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
-				AllowedSubcategories: allowedResourceSubcategories,
-				RequireSubcategory:   config.RequireResourceSubcategory,
+				AllowedSubcategories:   allowedResourceSubcategories,
+				RequireSubcategory:     config.RequireResourceSubcategory,
+				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
 		},
 		RegistryGuideFile: &check.RegistryGuideFileOptions{
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
-				AllowedSubcategories: allowedGuideSubcategories,
-				RequireSubcategory:   config.RequireGuideSubcategory,
+				AllowedSubcategories:   allowedGuideSubcategories,
+				RequireSubcategory:     config.RequireGuideSubcategory,
+				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
 		},
 		RegistryIndexFile: &check.RegistryIndexFileOptions{
@@ -290,8 +298,9 @@ Check that the current working directory or provided path is prefixed with terra
 			},
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
-				AllowedSubcategories: allowedResourceSubcategories,
-				RequireSubcategory:   config.RequireResourceSubcategory,
+				AllowedSubcategories:   allowedResourceSubcategories,
+				RequireSubcategory:     config.RequireResourceSubcategory,
+				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
 			ProviderName: config.ProviderName,
 		},

--- a/command/check.go
+++ b/command/check.go
@@ -123,6 +123,11 @@ func (c *CheckCommand) Run(args []string) int {
 
 	ConfigureLogging(c.Name(), config.LogLevel)
 
+	if config.RequireLayout && config.WarnDeprecatedFeatures {
+		c.Ui.Error("Using flags `-warn-deprecated-features` and `-require-layout` together will result in conflicting advice to both remove and add layout fields. Please use only one at a time.")
+		return 1
+	}
+
 	if config.ProviderName == "" && config.ProviderSource != "" {
 		providerSourceParts := strings.Split(config.ProviderSource, "/")
 		config.ProviderName = providerSourceParts[len(providerSourceParts)-1]

--- a/command/check.go
+++ b/command/check.go
@@ -35,6 +35,7 @@ type CheckCommandConfig struct {
 	ProviderSource                   string
 	ProvidersSchemaJson              string
 	RequireGuideSubcategory          bool
+	RequireLayout                    bool
 	RequireResourceSubcategory       bool
 	RequireSchemaOrdering            bool
 	WarnDeprecatedFeatures           bool
@@ -63,6 +64,7 @@ func (*CheckCommand) Help() string {
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-provider-source", "Terraform Provider source address (e.g. registry.terraform.io/hashicorp/aws) for Terraform CLI 0.13 and later -providers-schema-json. Automatically sets -provider-name by dropping hostname and namespace prefix.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-providers-schema-json", "Path to terraform providers schema -json file. Enables enhanced validations.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-require-guide-subcategory", "Require guide frontmatter subcategory.")
+	fmt.Fprintf(opts, CommandHelpOptionFormat, "-require-layout", "Require legacy index, guide, data source, and resource frontmatter to include layout.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-require-resource-subcategory", "Require data source and resource frontmatter subcategory.")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-require-schema-ordering", "Require schema attribute lists to be alphabetically ordered (requires -enable-contents-check).")
 	fmt.Fprintf(opts, CommandHelpOptionFormat, "-warn-deprecated-features", "Warn about deprecated frontmatter and files that can be removed.")
@@ -103,6 +105,7 @@ func (c *CheckCommand) Run(args []string) int {
 	flags.StringVar(&config.ProviderSource, "provider-source", "", "")
 	flags.StringVar(&config.ProvidersSchemaJson, "providers-schema-json", "", "")
 	flags.BoolVar(&config.RequireGuideSubcategory, "require-guide-subcategory", false, "")
+	flags.BoolVar(&config.RequireLayout, "require-layout", false, "")
 	flags.BoolVar(&config.RequireResourceSubcategory, "require-resource-subcategory", false, "")
 	flags.BoolVar(&config.RequireSchemaOrdering, "require-schema-ordering", false, "")
 	flags.BoolVar(&config.WarnDeprecatedFeatures, "warn-deprecated-features", false, "")
@@ -242,6 +245,7 @@ Check that the current working directory or provided path is prefixed with terra
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
 				AllowedSubcategories:   allowedResourceSubcategories,
+				RequireLayout:          config.RequireLayout,
 				RequireSubcategory:     config.RequireResourceSubcategory,
 				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
@@ -250,12 +254,16 @@ Check that the current working directory or provided path is prefixed with terra
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
 				AllowedSubcategories:   allowedGuideSubcategories,
+				RequireLayout:          config.RequireLayout,
 				RequireSubcategory:     config.RequireGuideSubcategory,
 				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},
 		},
 		LegacyIndexFile: &check.LegacyIndexFileOptions{
 			FileOptions: fileOpts,
+			FrontMatter: &check.FrontMatterOptions{
+				RequireLayout: config.RequireLayout,
+			},
 		},
 		LegacyResourceFile: &check.LegacyResourceFileOptions{
 			Contents: &check.ContentsOptions{
@@ -265,6 +273,7 @@ Check that the current working directory or provided path is prefixed with terra
 			FileOptions: fileOpts,
 			FrontMatter: &check.FrontMatterOptions{
 				AllowedSubcategories:   allowedResourceSubcategories,
+				RequireLayout:          config.RequireLayout,
 				RequireSubcategory:     config.RequireResourceSubcategory,
 				WarnDeprecatedFeatures: config.WarnDeprecatedFeatures,
 			},


### PR DESCRIPTION
# Description

## This PR does:

- Changes tests so they consider legacy documentation files that lack `layout` frontmatter as valid
- Updates the tool to have a `-require-layout` flag, which makes the tool return `YAML frontmatter missing required layout` errors when legacy files don't have `layout` present
- Updates the tool to have a `-warn-deprecated-features` flag that recommends users to remove `layout` frontmatter, as it's not used by the Registry anymore
- Validates flags in use, disallowing `-warn-deprecated-features` and `-require-layout` flags to be used at the same time.

My intention was to enable users to identify parts of their documentation that doesn't affect the final documentation rendered in the Registry. This will users start the process of migrating from legacy to current documentation standards, by reducing some of the 'noise' in legacy files 🤞 

Next I was thinking of extending `-warn-deprecated-features` to identify layout *.erb files and recommend deleting them (and I suppose we'd need `-require-layout` to identify the lack of a layout file), but not in this PR.

## Considerations for users - breaking changes?

If this change was merged we could affect existing users of the tool. I believe the only unexpected change a user could experience is that existing errors related to missing `layout` frontmatter will no longer be shown. This is because the tool previously enforced `layout` being present in legacy files, and this PR stops that. As the tool is getting more permissive I'd not characterise it as a breaking change (but defer to others!).

---

TODO:
 - [x] Add flag that lets the tool warn about unneeded `layout` frontmatter
 - [x] Update tool to only enforce presence of `layout` frontmatter when a flag is used
 - [x] Add validation to avoid those flags being used at the same time