### PR TITLE
check: handle empty provider name in mismatch check

### DIFF
--- a/check/file_mismatch.go
+++ b/check/file_mismatch.go
@@ -127,6 +127,10 @@ func fileHasResource(resourceNames []string, providerName, file string) bool {
 func fileResourceName(providerName, fileName string) string {
 	resourceSuffix := TrimFileExtension(fileName)
 
+	// providerName is empty for functions
+	if providerName == "" {
+		return resourceSuffix
+	}
 	return fmt.Sprintf("%s_%s", providerName, resourceSuffix)
 }
 

--- a/command/check.go
+++ b/command/check.go
@@ -255,7 +255,6 @@ Check that the current working directory or provided path is prefixed with terra
 		FunctionFileMismatch: &check.FileMismatchOptions{
 			IgnoreFileMismatch: ignoreFileMismatchFunctions,
 			IgnoreFileMissing:  ignoreFileMissingFunctions,
-			ProviderName:       config.ProviderName,
 			ResourceType:       check.ResourceTypeFunction,
 			ResourceNames:      functionNames,
 		},


### PR DESCRIPTION
This change will allow the file mismatch check to function properly for provider defined functions. Function file names will match the function name from the schema exactly, with no provider name prepended.

Closes #98 