### PR TITLE
Fix GoReleaser configuration deprecation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,7 +11,7 @@ brews:
   dependencies:
   - go
   description: Terraform Provider Documentation Tool
-  folder: Formula
+  directory: Formula
   repository:
     owner: bflad
     name: homebrew-tap


### PR DESCRIPTION
Previously:

```
❯ goreleaser check
  • checking                                 path=.goreleaser.yml
  • DEPRECATED:  brews.folder  should not be used anymore, check https://goreleaser.com/deprecations#brewsfolder for more info
  • .goreleaser.yml                                  error=configuration is valid, but uses deprecated properties
  ⨯ command failed                                   error=1 out of 1 configuration file(s) have issues
```